### PR TITLE
Fix mislabelling_finder path handling

### DIFF
--- a/mislabelling_finder.py
+++ b/mislabelling_finder.py
@@ -28,11 +28,11 @@ if __name__ == '__main__':
     log.info(f'{confidences.mean()*100:.2f}% of the train set is uncertain.')
     for i, e in tqdm(enumerate(confidences)):
         if e < 0.45:
-            data.train_ds.items[i].rename(Path('inputs\low_confidence') / data.train_ds.items[i].parent.name / data.train_ds.items[i].name)
+            data.train_ds.items[i].rename(Path('inputs/low_confidence') / data.train_ds.items[i].parent.name / data.train_ds.items[i].name)
 
     pred_values, _ = learn.get_preds(1)
     confidences = abs(pred_values.numpy()[:, 0] - 0.5)
     log.info(f'{confidences.mean()*100:.2f}% of the validation set is uncertain.')
     for i, e in tqdm(enumerate(confidences)):
         if e < 0.45:
-            data.valid_ds.items[i].rename(Path('inputs\low_confidence') / data.valid_ds.items[i].parent.name / data.valid_ds.items[i].name)
+            data.valid_ds.items[i].rename(Path('inputs/low_confidence') / data.valid_ds.items[i].parent.name / data.valid_ds.items[i].name)


### PR DESCRIPTION
## Summary
- fix path separator for low confidence images so that mislabelling finder
  works on POSIX systems

## Testing
- `python -m py_compile mislabelling_finder.py`
- `python -m py_compile FPSHighlighter.py fps_functions.py ml.py main.py dataset_pruner.py graph.py randomize.py`

------
https://chatgpt.com/codex/tasks/task_e_683fcbe9b89c8329aaf4f8ed44e31e19